### PR TITLE
macOS compatibility fixes

### DIFF
--- a/src/QArchive.cc
+++ b/src/QArchive.cc
@@ -1826,9 +1826,22 @@ int Reader::loopContent(void)
 
     qint64 blockSizeInBytes = (qint64)entry_stat->st_blksize;
     qint64 blocks = (qint64)entry_stat->st_blocks;
+
+    // For portability reasons
+    #if __APPLE__
+        #define st_atim st_atimespec
+        #define st_ctim st_ctimespec
+        #define st_mtim st_mtimespec
+    #endif
     auto lastAccessT = entry_stat->st_atim.tv_sec;
     auto lastModT = entry_stat->st_mtim.tv_sec;
     auto lastStatusModT = entry_stat->st_ctim.tv_sec;
+    #if __APPLE__
+        #undef st_atim
+        #undef st_ctim
+        #undef st_mtim
+    #endif
+
     QFileInfo fileInfo(CurrentFile);
 
     auto ft = archive_entry_filetype(entry);


### PR DESCRIPTION
**What kind of change does this pull request introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Describe your Pull Request:**

Apparently on Apple platforms, the stat struct doesn't have the `st_{a,c,m}tim` elements as is, they're named something else.

Because of this, QArchive didn't compile on macOS.

Solution: do just like https://github.com/tavianator/bfs/pull/13/commits/dd3c2a552725362cc03d7f7f631a0c24618cf4d2