### PR TITLE
Better progress report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+# C++ objects and libs
+*.slo
+*.lo
+*.o
+*.a
+*.la
+*.lai
+*.so
+*.dll
+*.dylib
+
+# Qt-es
+object_script.*.Release
+object_script.*.Debug
+*_plugin_import.cpp
+/.qmake.cache
+/.qmake.stash
+*.pro.user
+*.pro.user.*
+*.qbs.user
+*.qbs.user.*
+*.moc
+moc_*.cpp
+moc_*.h
+qrc_*.cpp
+ui_*.h
+*.qmlc
+*.jsc
+Makefile*
+*build-*
+*.qm
+
+# Qt unit tests
+target_wrapper.*
+
+# QtCreator
+*.autosave
+
+# QtCreator Qml
+*.qmlproject.user
+*.qmlproject.user.*
+
+# QtCreator CMake
+CMakeLists.txt.user*
+
+# QtCreator 4.8< compilation database 
+compile_commands.json
+
+# QtCreator local machine specific files for imported projects
+*creator.user*

--- a/docs/QArchiveDiskCompressor.md
+++ b/docs/QArchiveDiskCompressor.md
@@ -315,14 +315,15 @@ Cancels the compression of the archive. This slot is **async** and thus you need
 **canceled** signal , Which confirms that the cancel call was successfull.
 
 
-### void progress(QString file , int processedEntries , int totalEntries , int percentageDone)
+### void progress(QString file , int processedEntries , int totalEntries , qint64 bytesProcessed, qint64 bytesTotal)
 <p align="right"><b>[SIGNAL]</b></p>
 
 Emits the progress of the compression.
 
-The signal emits a total of **4 parameters** in which the **first one** is the file that has been compressed ,
+The signal emits a total of **5 parameters** in which the **first one** is the file that has been compressed ,
 the **second** is the number of files **that are compressed** , the **third** is the number of **total files** that is
-stagged for compression, and the **last one** is the **percentage** of compression done.
+stagged for compression, the **forth** is the number of bytes processed and the **last one** is the total number of bytes
+required for this compression.
 
 
 ### void started(void)

--- a/docs/QArchiveDiskCompressor.md
+++ b/docs/QArchiveDiskCompressor.md
@@ -322,7 +322,7 @@ Emits the progress of the compression.
 
 The signal emits a total of **5 parameters** in which the **first one** is the file that has been compressed ,
 the **second** is the number of files **that are compressed** , the **third** is the number of **total files** that is
-stagged for compression, the **forth** is the number of bytes processed and the **last one** is the total number of bytes
+stagged for compression, the **fourth** is the number of bytes processed and the **last one** is the total number of bytes
 required for this compression.
 
 

--- a/docs/QArchiveDiskCompressor.md
+++ b/docs/QArchiveDiskCompressor.md
@@ -57,7 +57,7 @@ This class belongs to QArchive namespace , so make sure to include it.
 
 |                     |                                                                                 |
 |---------------------|---------------------------------------------------------------------------------|
-| **void**            | [progress](#void-progressqstring-file-int-processedentries-int-totalentries-int-percentagedone)(QString, int, int, int)|
+| **void**            | [progress](#void-progressqstring-file-int-processedentries-int-totalentries-int-percentagedone)(QString, int, int, qint64, qint64)|
 | **void**	      | [started](#void-startedvoid)(void)                                              |
 | **void**            | [finished](#void-finishedvoid)(void)                        	                |
 | **void**            | [paused](#void-pausedvoid)(void)                                                |

--- a/docs/QArchiveDiskExtractor.md
+++ b/docs/QArchiveDiskExtractor.md
@@ -61,7 +61,7 @@ The class belongs to the QArchive namespace , so make sure to include it.
 |                     |                                                                                 |
 |---------------------|---------------------------------------------------------------------------------|
 | **void**            | [info](#void-infoqjsonobject-information)(QJsonObject)                          |
-| **void**            | [progress](#void-progressqstring-file-int-processedentries-int-totalentries-int-percentagedone)(QString, int, int, int)|
+| **void**            | [progress](#void-progressqstring-file-int-processedentries-int-totalentries-int-percentagedone)(QString, int, int, qint64, qint64)|
 | **void**            | [getInfoRequirePassword](#void-getinforequirepasswordint-numberoftries)(int)    |
 | **void**            | [extractionRequirePassword](#void-extractionrequirepasswordint-numberoftries)(int)|
 | **void**	      | [started](#void-startedvoid)(void)                                              |
@@ -336,7 +336,7 @@ The information is typically formated in the down below format with respect to J
    
    
 
-### void progress(QString file , int processedEntries , int totalEntries , int percentageDone)
+### void progress(QString file , int processedEntries , int totalEntries , qint64 bytesProcessed, qint64 bytesTotal)
 <p align="right"><b>[SIGNAL]</b></p>
 
 Emits the progress of the extraction , even if **setCalculateProgress** is set to **false** this signal
@@ -347,7 +347,8 @@ emitted integers.
 
 The signal emits a total of **4 parameters** in which the **first one** is the file that has been extracted ,
 the **second** is the number of files **that are extracted** , the **third** is the number of **total files** in the
-archive , and the **last one** is the **percentage** of extraction done.
+archive, the **fourth** is the number of bytes processed and the **last one** is the total number of bytes
+required for this extraction.
 
 ### void getInfoRequirePassword(int NumberOfTries)
 <p align="right"><b>[SIGNAL]</b></p>

--- a/docs/ReportingProgressGuide.md
+++ b/docs/ReportingProgressGuide.md
@@ -43,15 +43,15 @@ int main(int ac, char **av)
     });
     
     QObject::connect(&Extractor , &DiskExtractor::progress ,
-    [&](QString file , int proc , int total , int percent){
+    [&](QString file , int entriesProcessed , int entriesTotal , qint64 bytesProcessed, qint64 bytesTotal){
 	qInfo() << "Progress::" 
                 << file 
-                << ":: Done ( " 
-                << proc 
+                << ":: Entry ( " 
+                << entriesProcessed 
                 << " / " 
-                << total 
+                << entriesTotal 
                 << ") " 
-                << percent 
+                << float(bytesProcessed) * 100 / float(bytesTotal)
                 << "%.";
 	return;
     });

--- a/include/qarchivediskcompressor.hpp
+++ b/include/qarchivediskcompressor.hpp
@@ -37,7 +37,7 @@ class DiskCompressor : public QObject {
     void resume();
 
   Q_SIGNALS:
-    void progress(QString, int, int, int);
+    void progress(QString, int, int, qint64, qint64);
     void error(short, QString);
     void started();
     void canceled();

--- a/include/qarchivediskcompressor_p.hpp
+++ b/include/qarchivediskcompressor_p.hpp
@@ -43,7 +43,7 @@ class DiskCompressorPrivate : public QObject {
     short compress();
 
   Q_SIGNALS:
-    void progress(QString, int, int, int);
+    void progress(QString, int, int, qint64, qint64);
     void error(short, QString);
     void started();
     void canceled();
@@ -62,6 +62,8 @@ class DiskCompressorPrivate : public QObject {
     short m_ArchiveFormat = 0; /* Defaults to ZIP. */
     int n_BlockSize = 10240,
         n_TotalEntries = 0;
+    qint64 n_BytesProcessed = 0,
+           n_BytesTotal = 0;
     QSharedPointer<struct archive> m_ArchiveWrite;
     QScopedPointer<QSaveFile> m_TemporaryFile;
     QScopedPointer<QLinkedList<QPair<QString, QString>>> m_ConfirmedFiles;

--- a/include/qarchivediskextractor.hpp
+++ b/include/qarchivediskextractor.hpp
@@ -43,7 +43,7 @@ class DiskExtractor : public QObject {
     void resumed();
     void finished();
     void error(short);
-    void progress(QString, int, int, int);
+    void progress(QString, int, int, qint64, qint64);
     void getInfoRequirePassword(int);
     void extractionRequirePassword(int);
     void info(QJsonObject);

--- a/include/qarchivediskextractor_p.hpp
+++ b/include/qarchivediskextractor_p.hpp
@@ -49,7 +49,7 @@ class DiskExtractorPrivate : public QObject {
     void finished();
     void error(short);
     void info(QJsonObject);
-    void progress(QString, int, int, int);
+    void progress(QString, int, int, qint64, qint64);
     void getInfoRequirePassword(int);
     void extractionRequirePassword(int);
   private:
@@ -66,6 +66,8 @@ class DiskExtractorPrivate : public QObject {
         n_TotalEntries = -1,
         n_BlockSize = 10240,
         n_Flags = 0;
+    qint64 n_BytesProcessed = 0,
+           n_BytesTotal = 0;
 
     QString m_OutputDirectory,
             m_Password,

--- a/src/qarchivediskcompressor_p.cc
+++ b/src/qarchivediskcompressor_p.cc
@@ -240,6 +240,7 @@ void DiskCompressorPrivate::start() {
         }
 
         /* Confirm files. */
+        n_BytesTotal = 0;
         if(!confirmFiles()) {
             return;
         }
@@ -249,7 +250,6 @@ void DiskCompressorPrivate::start() {
     emit started();
 
     n_BytesProcessed = 0;
-    n_BytesTotal = 0;
 
     short ret = compress();
     if(ret == NoError) {

--- a/src/qarchivediskcompressor_p.cc
+++ b/src/qarchivediskcompressor_p.cc
@@ -8,6 +8,7 @@
 #include <qarchivediskcompressor_p.hpp>
 #include <qarchiveutils_p.hpp>
 #include <qarchive_enums.hpp>
+#include <QElapsedTimer>
 
 extern "C" {
 #include <archive.h>
@@ -207,6 +208,10 @@ void DiskCompressorPrivate::clear() {
     m_ArchiveFormat = 0;
     n_BlockSize = 10240;
 
+    // TODO: do we need to reset n_BytesTotal here?
+    n_BytesProcessed = 0;
+    n_BytesTotal = 0;
+
     m_ConfirmedFiles->clear();
     m_StaggedFiles->clear();
 
@@ -242,6 +247,9 @@ void DiskCompressorPrivate::start() {
 
     b_Started = true;
     emit started();
+
+    n_BytesProcessed = 0;
+    n_BytesTotal = 0;
 
     short ret = compress();
     if(ret == NoError) {
@@ -390,6 +398,9 @@ bool DiskCompressorPrivate::confirmFiles() {
                     }
                     fileNode.second = file;
                     m_ConfirmedFiles->append(fileNode);
+
+                    QFileInfo info(file);
+                    n_BytesTotal += info.size();
                 }
             }
         } else { /* Add it to the confirmed list. */
@@ -398,6 +409,7 @@ bool DiskCompressorPrivate::confirmFiles() {
             }
             node.second = info.filePath();
             m_ConfirmedFiles->append(node);
+            n_BytesTotal += info.size();
         }
     }
     return true;
@@ -531,10 +543,21 @@ short DiskCompressorPrivate::compress() {
                     emit error(DiskOpenError, node.second);
                     return DiskOpenError;
                 }
+                QElapsedTimer timer;
+                timer.start();
                 len = file->read(buff, sizeof(buff));
                 while (len > 0) {
                     archive_write_data(m_ArchiveWrite.data(), buff, len);
+                    n_BytesProcessed += len;
                     len = file->read(buff, sizeof(buff));
+
+                    if (timer.hasExpired(100)) {
+                        emit progress(QString(node.second),
+                                      (n_TotalEntries - m_ConfirmedFiles->size()),
+                                      n_TotalEntries, n_BytesProcessed, n_BytesTotal);
+
+                        timer.restart();
+                    }
                 }
                 file->close();
             }
@@ -542,8 +565,7 @@ short DiskCompressorPrivate::compress() {
 
         emit progress(QString(node.second),
                       (n_TotalEntries - m_ConfirmedFiles->size()),
-                      n_TotalEntries,
-                      ((n_TotalEntries - m_ConfirmedFiles->size())*100)/n_TotalEntries);
+                      n_TotalEntries, n_BytesProcessed, n_BytesTotal);
 
 
         QCoreApplication::processEvents();

--- a/tests/QArchiveDiskCompressorTests.hpp
+++ b/tests/QArchiveDiskCompressorTests.hpp
@@ -128,11 +128,26 @@ class QArchiveDiskCompressorTests : public QObject,private QArchiveTestCases {
 
         QObject::connect(&e, &QArchive::DiskCompressor::error,
                          this, &QArchiveDiskCompressorTests::defaultErrorHandler);
-        QSignalSpy spyInfo(&e, SIGNAL(finished()));
+        QSignalSpy finishedSpyInfo(&e, SIGNAL(finished()));
+        QSignalSpy progressSpyInfo(&e, SIGNAL(progress(QString, int, int, qint64, qint64)));
         e.start();
 
-        QVERIFY(spyInfo.wait() || spyInfo.count());
+        QVERIFY(finishedSpyInfo.wait() || finishedSpyInfo.count());
         QVERIFY(QFileInfo::exists(TestCase3ArchivePath));
+
+        QCOMPARE(progressSpyInfo.count(), 2);
+
+        QList<QVariant> progress1 = progressSpyInfo.takeFirst();
+        QVERIFY(progress1.at(1).toInt() == 1);
+        QVERIFY(progress1.at(2).toInt() == 2);
+        QVERIFY(progress1.at(3).toInt() == 14);
+        QVERIFY(progress1.at(4).toInt() == 28);
+
+        QList<QVariant> progress2 = progressSpyInfo.takeLast();
+        QVERIFY(progress2.at(1).toInt() == 2);
+        QVERIFY(progress2.at(2).toInt() == 2);
+        QVERIFY(progress2.at(3).toInt() == 28);
+        QVERIFY(progress2.at(4).toInt() == 28);
     }
 
     void encryptingZipArchive() {

--- a/tests/QArchiveDiskCompressorTests.hpp
+++ b/tests/QArchiveDiskCompressorTests.hpp
@@ -141,13 +141,13 @@ class QArchiveDiskCompressorTests : public QObject,private QArchiveTestCases {
         QVERIFY(progress1.at(1).toInt() == 1);
         QVERIFY(progress1.at(2).toInt() == 2);
         QVERIFY(progress1.at(3).toInt() == 14);
-        QVERIFY(progress1.at(4).toInt() == 28);
+        QVERIFY(progress1.at(4).toInt() == 68);
 
         QList<QVariant> progress2 = progressSpyInfo.takeLast();
         QVERIFY(progress2.at(1).toInt() == 2);
         QVERIFY(progress2.at(2).toInt() == 2);
-        QVERIFY(progress2.at(3).toInt() == 28);
-        QVERIFY(progress2.at(4).toInt() == 28);
+        QVERIFY(progress2.at(3).toInt() == 68);
+        QVERIFY(progress2.at(4).toInt() == 68);
     }
 
     void encryptingZipArchive() {

--- a/tests/QArchiveTestCases.hpp
+++ b/tests/QArchiveTestCases.hpp
@@ -78,7 +78,7 @@ class QArchiveTestCases {
     const QString Test1OutputContents = QString("TEST1SUCCESS!");
     const QString Test2OutputContents = QString("TEST2SUCCESS!");
     const QString Test3Output1Contents = QString("TEST3SUCCESS1!");
-    const QString Test3Output2Contents = QString("TEST3SUCCESS2!");
+    const QString Test3Output2Contents = QString("TEST3SUCCESS2!_SOME_MORE_CONTENT_TO_CALCULATE_PROGRESS");
     const QString Test4Password = QString("Test4");
     const QString Test4OutputContents = QString("TEST4SUCCESS!");
     const QString Test5OutputContents = QString("TEST5SUCCESS!");


### PR DESCRIPTION
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this pull request introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Describe your Pull Request:**
See https://github.com/antony-jr/QArchive/issues/23

**BREAKING CHANGES:**
I changed `progress` signal to: 
````
void progress(QString file , int processedEntries , int totalEntries , qint64 bytesProcessed, qint64 bytesTotal)
````

This way user can decide how to calculate the progress themselves. In my application, I need to calculate both progress and write speed.