### PR TITLE
Add conan example & update include path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ compile_commands.json
 
 # QtCreator local machine specific files for imported projects
 *creator.user*
+
+# Conan example build folder
+examples/conan/build

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Qt Installer Framework.
 
 ```
 #include <QCoreApplication>
-#include <QArchive>
+#include <QArchive/QArchive>
 
 int main(int argc, char **argv)
 {

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ int main(int argc, char **argv)
 
 Learn more about **QArchive** at the official [documentation](https://antony-jr.github.io/QArchive).
 
+## Conan
+
+Starting version 2.0.1 `QArchive` is available on the [Conan C/C++ package manager](https://conan.io/), which means you can download prebuilt packages for all major platforms (Windows, Linux, macOS, etc).
+
+Find an example on how to consume Conan's precompiled packages in the examples folder.
+
 # Contributors [![QArchive Contributors](https://img.shields.io/github/contributors/antony-jr/QArchive.svg)](https://github.com/antony-jr/QArchive/graphs/contributors)
 
 My utmost **gratitude goes to these people!** :heart:

--- a/docs/AddingToYourQtProject.md
+++ b/docs/AddingToYourQtProject.md
@@ -71,7 +71,7 @@ SUBDIRS = libs \ # Always use this order
 Whenever you want to use **QArchive** , you just need to include it!
 
 ```
-#include <QArchive>
+#include <QArchive/QArchive>
 ```
 
 
@@ -122,6 +122,6 @@ include(QArchive/QArchive.pri)
 Whenever you want to use **QArchive** , you just need to include it!
 
 ```
-#include <QArchive>
+#include <QArchive/QArchive>
 ```
 

--- a/docs/CreatingEncryptedZipArchiveGuide.md
+++ b/docs/CreatingEncryptedZipArchiveGuide.md
@@ -18,7 +18,7 @@ encrypt the archive using a password.
 ```
 #include <QCoreApplication>
 #include <QDebug>
-#include <QArchive>
+#include <QArchive/QArchive>
 
 int main(int argc, char** argv)
 {

--- a/docs/ExtractingPasswordProtectedArchiveGuide.md
+++ b/docs/ExtractingPasswordProtectedArchiveGuide.md
@@ -14,7 +14,7 @@ This simple example extracts a given archive which is encrypted.
 #include <string>
 #include <QCoreApplication>
 #include <QDebug>
-#include <QArchive>
+#include <QArchive/QArchive>
 
 int main(int ac, char **av)
 {

--- a/docs/ReportingProgressGuide.md
+++ b/docs/ReportingProgressGuide.md
@@ -14,7 +14,7 @@ Eventhough this example is for the extractor , the same can be used for
 ```
 #include <QCoreApplication>
 #include <QDebug>
-#include <QArchive>
+#include <QArchive/QArchive>
 
 int main(int ac, char **av)
 {

--- a/docs/SimpleCompressorGuide.md
+++ b/docs/SimpleCompressorGuide.md
@@ -13,7 +13,7 @@ This simple example compresses a set of files and directories.(Directories are r
 ```
 #include <QCoreApplication>
 #include <QDebug>
-#include <QArchive>
+#include <QArchive/QArchive>
 
 int main(int argc, char** argv)
 {

--- a/docs/SimpleExtractorGuide.md
+++ b/docs/SimpleExtractorGuide.md
@@ -12,7 +12,7 @@ This simple example extracts a given archive supported by libarchive.
 ```
 #include <QCoreApplication>
 #include <QDebug>
-#include <QArchive>
+#include <QArchive/QArchive>
 
 int main(int ac, char **av)
 {

--- a/examples/conan/CMakeLists.txt
+++ b/examples/conan/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.15)
+project(quarchiveProject CXX)
+
+# conan.cmake will be here
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
+
+# Conan-generated files will be here. We care about FindQArchive.cmake
+list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
+
+# Download conan.cmake module, used to automate conan calls.
+# This could be replaced with manual conan calls before the cmake calls.
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
+  message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
+  file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.16.1/conan.cmake"
+                "${CMAKE_BINARY_DIR}/conan.cmake"
+                TLS_VERIFY ON)
+endif()
+
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE RELEASE)
+endif()
+
+include(${CMAKE_BINARY_DIR}/conan.cmake)
+
+# Autodetect system settings so the example is crossplatform.
+conan_cmake_autodetect(settings)
+
+# Pull the QArchive and all its transitive dependencies. Since QArchive depends on Qt,
+# there are a lot of transitive dependencies.
+# This command also generate all the conan findPKG.cmake modules.
+conan_cmake_install(PATH_OR_REFERENCE ${CMAKE_SOURCE_DIR}/conanfile.py
+                    REMOTE conan-center
+                    SETTINGS ${settings}
+)
+
+find_package(QArchive REQUIRED)
+
+add_executable(${PROJECT_NAME} main.cpp)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+
+# This is a requirement since we're using Conan's qt5
+target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
+
+target_link_libraries(${PROJECT_NAME} QArchive::QArchive)
+

--- a/examples/conan/README.md
+++ b/examples/conan/README.md
@@ -1,0 +1,20 @@
+# QArchive & Conan example
+
+## Intro
+Starting version 2.0.1 `QArchive` is available on the [Conan C/C++ package manager](https://conan.io/), which means you can download prebuilt packages for all major platforms (Windows, Linux, macOS, etc).
+
+## Build
+The CMakeLists in this example will pull the `conan.cmake` module, which will automate all the Conan calls. That snippet can be replaced with manual Conan calls if desired.
+
+```bash
+pip install conan
+
+mkdir build && cd build
+
+cmake .. && cmake --build -jn .
+./quarchiveProject
+```
+## Notice
+1. The `-fPIC` compile option is needed to use Conan's qt5
+2. Components are not supported on Conan's qt5 (yet), so the whole qt package is linked against.
+3. `CMAKE_AUTOMOC` doesn't currently work with Conan's qt5. Use `qt5_wrap_cpp()` in te mean time.

--- a/examples/conan/conanfile.py
+++ b/examples/conan/conanfile.py
@@ -1,0 +1,11 @@
+from conans import ConanFile, CMake
+
+class Conan(ConanFile):
+   name = "qarchiveConanExample"
+   version = "1.0.0"
+   settings = "arch"
+   # By setting this this generator we instruct conan to generate the findPKG.cmake files.
+   generators = "cmake_find_package"
+
+   def configure(self):
+      self.requires("qarchive/2.0.1")

--- a/examples/conan/main.cpp
+++ b/examples/conan/main.cpp
@@ -1,0 +1,60 @@
+#include <QCoreApplication>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QDir>
+#include <QDebug>
+#include <QArchive/QArchive>
+
+
+int main(int ac, char **av) {
+        QCoreApplication app(ac, av);
+        QTemporaryDir dir;
+        QString data = QString::fromUtf8("Some Text to Compress.");
+        QFile textFile;
+        textFile.setFileName(dir.path() + QDir::separator() + "TextFile.txt");
+        if(!textFile.open(QIODevice::WriteOnly)) {
+                return -1;
+        }
+
+        textFile.write(data.toUtf8());
+        textFile.close();
+
+        QArchive::DiskCompressor compressor;
+        QArchive::DiskExtractor extractor;
+
+        compressor.setFileName(dir.path() + QDir::separator() + "Test.zip");
+        compressor.addFiles(QString::fromUtf8("Output.txt") , dir.path() + QDir::separator() + "TextFile.txt");
+
+        extractor.setArchive(dir.path() + QDir::separator() + "Test.zip");
+        extractor.setOutputDirectory(dir.path());
+
+        QObject::connect(&compressor, &QArchive::DiskCompressor::finished,
+        [&]() {
+                extractor.start();
+        });
+
+        QObject::connect(&extractor, &QArchive::DiskExtractor::finished,
+        [&]() {
+                /// Check if the data is correct.
+                QFile file;
+                file.setFileName(dir.path() + QDir::separator() + "Output.txt");
+                if(!file.open(QIODevice::ReadOnly)){
+                        qDebug() << "Cannot Open Output.txt!";
+                        app.quit();
+                }
+
+                auto got = QString(file.readAll());
+                file.close();
+
+                if(got != data) {
+                        qDebug() << "Data does not Match: " << got;
+                        app.quit();
+                }
+                qDebug() << "Data: " << got;
+                qDebug() << "Test Finished.";
+                app.quit();
+        });
+
+        compressor.start();
+        return app.exec();
+}

--- a/examples/disk_compressor/main.cc
+++ b/examples/disk_compressor/main.cc
@@ -1,6 +1,6 @@
 #include <QCoreApplication>
 #include <QDebug>
-#include <QArchive>
+#include <QArchive/QArchive>
 
 int main(int ac, char **av) {
     if(ac < 2) {

--- a/examples/disk_extractor/main.cc
+++ b/examples/disk_extractor/main.cc
@@ -2,7 +2,7 @@
 #include <string>
 #include <QCoreApplication>
 #include <QDebug>
-#include <QArchive>
+#include <QArchive/QArchive>
 #include <QJsonObject>
 
 int main(int ac, char **av) {

--- a/examples/disk_extractor_with_QIODevice/main.cc
+++ b/examples/disk_extractor_with_QIODevice/main.cc
@@ -2,7 +2,7 @@
 #include <string>
 #include <QCoreApplication>
 #include <QDebug>
-#include <QArchive>
+#include <QArchive/QArchive>
 #include <QJsonObject>
 #include <QFile>
 

--- a/tests/QArchiveDiskCompressorTests.hpp
+++ b/tests/QArchiveDiskCompressorTests.hpp
@@ -1,4 +1,4 @@
-#include <QArchive>
+#include <QArchive/QArchive>
 #include <QTest>
 #include <QFileInfo>
 #include <QTimer>

--- a/tests/QArchiveDiskExtractorTests.hpp
+++ b/tests/QArchiveDiskExtractorTests.hpp
@@ -1,4 +1,4 @@
-#include <QArchive>
+#include <QArchive/QArchive>
 #include <QTest>
 #include <QTimer>
 #include <QJsonObject>


### PR DESCRIPTION
Adding example on how to consume the Conan package of QArchive.

I took the liberty to also fix the include path of the QArchive header. On version 2.0.1 it changed from `#include <QArchive>` to `#include <QArchive/QArchive>`