### PR TITLE
Fix missing QT_VERSION_MAJOR variable in cmake configuration.

### DIFF
--- a/other/cmake/QArchiveConfig.cmake.in
+++ b/other/cmake/QArchiveConfig.cmake.in
@@ -1,6 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_dependency(Qt${QT_VERSION_MAJOR}Core)
 find_dependency(LibArchive)
 


### PR DESCRIPTION
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this pull request introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

Sorry I missed that change in the previous Qt6 support PR.
I didn't notice it immediately as it is only popping up when doing _find_package(QArchive)_ in another project CMakeList.
