### PR TITLE
Adopt to libarchive prior 3 5 0 version

### DIFF
--- a/include/qarchive_enums.hpp
+++ b/include/qarchive_enums.hpp
@@ -42,6 +42,7 @@ enum : short {
     NoPermissionToReadArchive,
     InvalidOutputDirectory,
     InvalidArchiveFile,
+    ApplyPatternFailed,
 };
 
 /*

--- a/include/qarchiveextractor.hpp
+++ b/include/qarchiveextractor.hpp
@@ -28,6 +28,10 @@ class QARCHIVE_EXPORT Extractor : public QObject {
     void setPassword(const QString&);
     void addFilter(const QString&);
     void addFilter(const QStringList&);
+    void addIncludePattern(const QString&);
+    void addIncludePattern(const QStringList&);
+    void addExcludePattern(const QString&);
+    void addExcludePattern(const QStringList&);
     void clear();
 
     void getInfo();

--- a/include/qarchiveextractor.hpp
+++ b/include/qarchiveextractor.hpp
@@ -32,6 +32,7 @@ class QARCHIVE_EXPORT Extractor : public QObject {
     void addIncludePattern(const QStringList&);
     void addExcludePattern(const QString&);
     void addExcludePattern(const QStringList&);
+    void setBasePath(const QString&);
     void clear();
 
     void getInfo();

--- a/include/qarchiveextractor_p.hpp
+++ b/include/qarchiveextractor_p.hpp
@@ -10,6 +10,7 @@
 #include <QScopedPointer>
 #include <QSharedPointer>
 #include <QJsonObject>
+#include <QDir>
 
 #include "qarchivememoryextractoroutput.hpp"
 #include "qarchiveutils_p.hpp"
@@ -51,6 +52,7 @@ class ExtractorPrivate : public QObject {
     void addIncludePattern(const QStringList&);
     void addExcludePattern(const QString&);
     void addExcludePattern(const QStringList&);
+    void setBasePath(const QString&);
     void clear();
 
     void getInfo();
@@ -110,6 +112,8 @@ class ExtractorPrivate : public QObject {
     QScopedPointer<QJsonObject> m_Info;
     QScopedPointer<QVector<MemoryFile>> m_ExtractedFiles;
     QSharedPointer<ArchiveFilter> m_archiveFilter;
+    bool b_hasBasePath = false;
+    QDir m_basePath;
 };
 }
 #endif // QARCHIVE_EXTRACTOR_PRIVATE_HPP_INCLUDED

--- a/include/qarchiveextractor_p.hpp
+++ b/include/qarchiveextractor_p.hpp
@@ -15,6 +15,9 @@
 #include "qarchiveutils_p.hpp"
 
 namespace QArchive {
+
+class ArchiveFilter;
+
 class MutableMemoryFile {
   public:
     MutableMemoryFile();
@@ -44,6 +47,10 @@ class ExtractorPrivate : public QObject {
     void setPassword(const QString&);
     void addFilter(const QString&);
     void addFilter(const QStringList&);
+    void addIncludePattern(const QString&);
+    void addIncludePattern(const QStringList&);
+    void addExcludePattern(const QString&);
+    void addExcludePattern(const QStringList&);
     void clear();
 
     void getInfo();
@@ -99,9 +106,10 @@ class ExtractorPrivate : public QObject {
     MutableMemoryFile m_CurrentMemoryFile;
     QSharedPointer<struct archive> m_ArchiveRead;
     QSharedPointer<struct archive> m_ArchiveWrite;
-    QScopedPointer<QStringList> m_ExtractFilters;
+    QStringList m_ExtractFilters;
     QScopedPointer<QJsonObject> m_Info;
     QScopedPointer<QVector<MemoryFile>> m_ExtractedFiles;
+    QSharedPointer<ArchiveFilter> m_archiveFilter;
 };
 }
 #endif // QARCHIVE_EXTRACTOR_PRIVATE_HPP_INCLUDED

--- a/src/qarchivecompressor_p.cc
+++ b/src/qarchivecompressor_p.cc
@@ -799,9 +799,9 @@ short CompressorPrivate::compress() {
             archive_entry_set_pathname(entry.data(), (node->entry).toUtf8().constData());
             archive_entry_set_filetype(entry.data(), AE_IFREG);
             archive_entry_set_size(entry.data(), (node->io)->size());
-	    archive_entry_set_atime(entry.data(), (time_t)datetime.currentSecsSinceEpoch(), 0);
-	    archive_entry_set_mtime(entry.data(), (time_t)datetime.currentSecsSinceEpoch(), 0);
-	    archive_entry_set_birthtime(entry.data(), (time_t)datetime.currentSecsSinceEpoch(), 0);
+	    archive_entry_set_atime(entry.data(), static_cast<time_t>(datetime.toTime_t()), 0);
+	    archive_entry_set_mtime(entry.data(), static_cast<time_t>(datetime.toTime_t()), 0);
+	    archive_entry_set_birthtime(entry.data(), static_cast<time_t>(datetime.toTime_t()), 0);
 
             (node->io)->seek(0);
 

--- a/src/qarchiveextractor.cc
+++ b/src/qarchiveextractor.cc
@@ -121,36 +121,44 @@ void Extractor::addFilter(const QStringList &filters) {
     return;
 }
 
-void Extractor::addIncludePattern(const QString &filter) {
+void Extractor::addIncludePattern(const QString &pattern) {
     getMethod(m_Extractor,
               "addIncludePattern(const QString&)").invoke(m_Extractor.data(),
                       Qt::QueuedConnection,
-                      Q_ARG(QString, filter));
+                      Q_ARG(QString, pattern));
     return;
 }
 
-void Extractor::addIncludePattern(const QStringList &filters) {
+void Extractor::addIncludePattern(const QStringList &patterns) {
     getMethod(m_Extractor,
               "addIncludePattern(const QStringList&)").invoke(m_Extractor.data(),
                       Qt::QueuedConnection,
-                      Q_ARG(QStringList, filters));
+                      Q_ARG(QStringList, patterns));
     return;
 }
 
 
-void Extractor::addExcludePattern(const QString &filter) {
+void Extractor::addExcludePattern(const QString & pattern) {
     getMethod(m_Extractor,
               "addExcludePattern(const QString&)").invoke(m_Extractor.data(),
                       Qt::QueuedConnection,
-                      Q_ARG(QString, filter));
+                      Q_ARG(QString, pattern));
     return;
 }
 
-void Extractor::addExcludePattern(const QStringList &filters) {
+void Extractor::addExcludePattern(const QStringList & patterns) {
     getMethod(m_Extractor,
               "addExcludePattern(const QStringList&)").invoke(m_Extractor.data(),
                       Qt::QueuedConnection,
-                      Q_ARG(QStringList, filters));
+                      Q_ARG(QStringList, patterns));
+    return;
+}
+
+void Extractor::setBasePath(const QString &path) {
+    getMethod(m_Extractor,
+              "setBasePath(const QString&)").invoke(m_Extractor.data(),
+                      Qt::QueuedConnection,
+                      Q_ARG(QString, path));
     return;
 }
 

--- a/src/qarchiveextractor.cc
+++ b/src/qarchiveextractor.cc
@@ -121,6 +121,39 @@ void Extractor::addFilter(const QStringList &filters) {
     return;
 }
 
+void Extractor::addIncludePattern(const QString &filter) {
+    getMethod(m_Extractor,
+              "addIncludePattern(const QString&)").invoke(m_Extractor.data(),
+                      Qt::QueuedConnection,
+                      Q_ARG(QString, filter));
+    return;
+}
+
+void Extractor::addIncludePattern(const QStringList &filters) {
+    getMethod(m_Extractor,
+              "addIncludePattern(const QStringList&)").invoke(m_Extractor.data(),
+                      Qt::QueuedConnection,
+                      Q_ARG(QStringList, filters));
+    return;
+}
+
+
+void Extractor::addExcludePattern(const QString &filter) {
+    getMethod(m_Extractor,
+              "addExcludePattern(const QString&)").invoke(m_Extractor.data(),
+                      Qt::QueuedConnection,
+                      Q_ARG(QString, filter));
+    return;
+}
+
+void Extractor::addExcludePattern(const QStringList &filters) {
+    getMethod(m_Extractor,
+              "addExcludePattern(const QStringList&)").invoke(m_Extractor.data(),
+                      Qt::QueuedConnection,
+                      Q_ARG(QStringList, filters));
+    return;
+}
+
 void Extractor::clear() {
     getMethod(m_Extractor, "clear()").invoke(m_Extractor.data(), Qt::QueuedConnection);
     return;


### PR DESCRIPTION
- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

+Add: Support for older libarchive versions like 3.1.2 that are quite commonly used in embedded development.
+Fix: archive information population. Get rid of archive_entry_stat() call since it internally just populates struct stat that gives us nothing except losing data during conversion that led to incorrect st_size member value. 
+Fix: BlockSize and Blocks calculation. The libarchive doesn't populate these fields. So, use 512 as the most likely value and size for the calculations. 
+Add: RawSize member to entry info.
+Fix: Add entry size to n_BytesProcessed of skipped entries. Moved n_BytesProcessed reset to place where archives are setup. 
+Add: Add include/exclude patterns matching on entries extraction to allow filtering the same way as bsd tar does. 
+Add: "Excluded" attribute to archive entry information to inform info consumer whatever the entry is being skipped while extracting.
+Add: base path feature that allows to remove common leading part of the path while extracting.