### PR TITLE
Add support for QT6 since some QDateTime methods are gone (see PR #45)

### DIFF
--- a/src/qarchivecompressor_p.cc
+++ b/src/qarchivecompressor_p.cc
@@ -812,13 +812,18 @@ short CompressorPrivate::compress() {
                              ArchiveEntryDestructor);
 
             // Setup archive entry.
-            auto datetime = QDateTime::currentDateTime();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 8, 0))
+            time_t datetime = static_cast<time_t>(QDateTime::currentDateTime().toSecsSinceEpoch());
+#else
+            time_t datetime = static_cast<time_t>(QDateTime::currentDateTime().toTime_t());
+#endif
+
             archive_entry_set_pathname(entry.data(), (node->entry).toUtf8().constData());
             archive_entry_set_filetype(entry.data(), AE_IFREG);
             archive_entry_set_size(entry.data(), (node->io)->size());
-            archive_entry_set_atime(entry.data(), static_cast<time_t>(datetime.toTime_t()), 0);
-            archive_entry_set_mtime(entry.data(), static_cast<time_t>(datetime.toTime_t()), 0);
-            archive_entry_set_birthtime(entry.data(), static_cast<time_t>(datetime.toTime_t()), 0);
+            archive_entry_set_atime(entry.data(), datetime, 0);
+            archive_entry_set_mtime(entry.data(), datetime, 0);
+            archive_entry_set_birthtime(entry.data(), datetime, 0);
 
             (node->io)->seek(0);
 


### PR DESCRIPTION
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this pull request introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Describe your Pull Request:**

Based on #45, switch the medthod to get a time_t from QT depending on QT version.
