### PR TITLE
add missing header for Windows

### DIFF
--- a/include/qarchivecompressor_p.hpp
+++ b/include/qarchivecompressor_p.hpp
@@ -6,6 +6,7 @@
 #include <QFile>
 #include <QBuffer>
 #include <QSaveFile>
+#include <QVariantList>
 #include <QVector>
 #include <QScopedPointer>
 #include <QSharedPointer>


### PR DESCRIPTION
It seems this header is not implicitly included in Windows.

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

Fixes: https://github.com/antony-jr/QArchive/issues/51