### PR TITLE
Remove zstd support if QArchive is built against Libarchive prior version 3.3.3

### DIFF
--- a/src/qarchivecompressor_p.cc
+++ b/src/qarchivecompressor_p.cc
@@ -615,6 +615,7 @@ short CompressorPrivate::compress() {
             archive_write_add_filter_none(m_ArchiveWrite.data());
             archive_write_set_format_7zip(m_ArchiveWrite.data());
             break;
+#if (ARCHIVE_VERSION_NUMBER >= 3003003)
         case ZstdFormat:
             archive_write_add_filter_zstd(m_ArchiveWrite.data());
             /*
@@ -630,6 +631,7 @@ short CompressorPrivate::compress() {
                 archive_write_set_format_iso9660(m_ArchiveWrite.data());
             }
             break;
+#endif
         default:
             archive_write_add_filter_none(m_ArchiveWrite.data());
             archive_write_set_format_zip(m_ArchiveWrite.data());


### PR DESCRIPTION
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this pull request introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Describe your Pull Request:**
libarchive supports zstd from version 3.3.3 only. So, I've added logic to remove zstd support if we build against older version.
