### PR TITLE
Use zstd if libarchive supports it and fall-back to zip otherwise.

### DIFF
--- a/src/qarchivecompressor_p.cc
+++ b/src/qarchivecompressor_p.cc
@@ -616,6 +616,7 @@ short CompressorPrivate::compress() {
             archive_write_set_format_7zip(m_ArchiveWrite.data());
             break;
         case ZstdFormat:
+#if ARCHIVE_VERSION_NUMBER >= 3003003
             archive_write_add_filter_zstd(m_ArchiveWrite.data());
             /*
              * TODO: Investigate more on this.
@@ -629,6 +630,10 @@ short CompressorPrivate::compress() {
             } else {
                 archive_write_set_format_iso9660(m_ArchiveWrite.data());
             }
+#else // Explicitly fall-back to zip if libarchive doesn't support zstd.
+            archive_write_add_filter_none(m_ArchiveWrite.data());
+            archive_write_set_format_zip(m_ArchiveWrite.data());
+#endif
             break;
         default:
             archive_write_add_filter_none(m_ArchiveWrite.data());


### PR DESCRIPTION
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this pull request introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Describe your Pull Request:**
libarchive supports zstd from version 3.3.3 only. So, I've added logic to fall-back to zip if we build against older version.
The fall-back is required to allow tests pass and to avoid changes in code that uses QArchive