### PR TITLE
QSharedPointer to std::shared_ptr

### DIFF
--- a/include/qarchiveextractor_p.hpp
+++ b/include/qarchiveextractor_p.hpp
@@ -32,10 +32,10 @@ class MutableMemoryFile {
     void setBuffer(QBuffer*);
 
     [[gnu::warn_unused_result]] QJsonObject getFileInformation() const;
-    [[gnu::warn_unused_result]] QSharedPointer<QBuffer> getBuffer() const;
+    [[gnu::warn_unused_result]] std::shared_ptr<QBuffer> getBuffer() const;
   private:
     QJsonObject m_FileInformation;
-    QSharedPointer<QBuffer> m_Buffer;
+    std::shared_ptr<QBuffer> m_Buffer;
 };
 
 class ExtractorPrivate : public QObject {

--- a/include/qarchiveextractor_p.hpp
+++ b/include/qarchiveextractor_p.hpp
@@ -22,12 +22,6 @@ class ArchiveFilter;
 
 class MutableMemoryFile {
   public:
-    MutableMemoryFile();
-    ~MutableMemoryFile();
-
-    MutableMemoryFile(const MutableMemoryFile&) = default;
-    MutableMemoryFile& operator=(const MutableMemoryFile&) = default;
-
     void setFileInformation(const QJsonObject&);
     void setBuffer(QBuffer*);
 

--- a/include/qarchivememoryextractor.hpp
+++ b/include/qarchivememoryextractor.hpp
@@ -1,6 +1,5 @@
 #ifndef QARCHIVE_MEMORY_EXTRACTOR_HPP_INCLUDED
 #define QARCHIVE_MEMORY_EXTRACTOR_HPP_INCLUDED
-#include <QSharedPointer>
 #include <QBuffer>
 #include <QIODevice>
 #include <QString>

--- a/include/qarchivememoryfile.hpp
+++ b/include/qarchivememoryfile.hpp
@@ -3,6 +3,8 @@
 #include <QBuffer>
 #include <QJsonObject>
 
+#include <memory>
+
 #include "qarchive_global.hpp"
 
 namespace QArchive {
@@ -13,7 +15,7 @@ class QARCHIVE_EXPORT MemoryFile {
     ~MemoryFile() = default;
 
     [[gnu::warn_unused_result]] QJsonObject fileInformation() const;
-    [[gnu::warn_unused_result]] QBuffer *buffer() const;
+    [[gnu::warn_unused_result]] std::shared_ptr<QBuffer> buffer() const;
   private:
     QJsonObject m_FileInformation;
     std::shared_ptr<QBuffer> m_Buffer;

--- a/include/qarchivememoryfile.hpp
+++ b/include/qarchivememoryfile.hpp
@@ -1,6 +1,5 @@
 #ifndef QARCHIVE_MEMORY_FILE_HPP_INCLUDED
 #define QARCHIVE_MEMORY_FILE_HPP_INCLUDED
-#include <QSharedPointer>
 #include <QBuffer>
 #include <QJsonObject>
 
@@ -10,7 +9,7 @@ namespace QArchive {
 class QARCHIVE_EXPORT MemoryFile {
   public:
     MemoryFile();
-    MemoryFile(QJsonObject, const QSharedPointer<QBuffer>&);
+    MemoryFile(QJsonObject, std::shared_ptr<QBuffer>);
     ~MemoryFile();
 
     MemoryFile(const MemoryFile&) = default;
@@ -20,7 +19,7 @@ class QARCHIVE_EXPORT MemoryFile {
     [[gnu::warn_unused_result]] QBuffer *buffer() const;
   private:
     QJsonObject m_FileInformation;
-    QSharedPointer<QBuffer> m_Buffer;
+    std::shared_ptr<QBuffer> m_Buffer;
 };
 }  // namespace QArchive
 

--- a/include/qarchivememoryfile.hpp
+++ b/include/qarchivememoryfile.hpp
@@ -8,12 +8,9 @@
 namespace QArchive {
 class QARCHIVE_EXPORT MemoryFile {
   public:
-    MemoryFile();
     MemoryFile(QJsonObject, std::shared_ptr<QBuffer>);
-    ~MemoryFile();
-
-    MemoryFile(const MemoryFile&) = default;
-    MemoryFile& operator=(const MemoryFile&) = default;
+    MemoryFile() = default;
+    ~MemoryFile() = default;
 
     [[gnu::warn_unused_result]] QJsonObject fileInformation() const;
     [[gnu::warn_unused_result]] QBuffer *buffer() const;

--- a/src/qarchiveextractor_p.cc
+++ b/src/qarchiveextractor_p.cc
@@ -30,11 +30,6 @@ using namespace QArchive;
 /// This will force the users to not mess up the integrity of a MemoryFile like
 /// deleting the internal pointers which will be automatically freed by MemoryFile
 /// destructor.
-MutableMemoryFile::MutableMemoryFile() = default;
-MutableMemoryFile::~MutableMemoryFile() {
-    m_Buffer = {};
-}
-
 void MutableMemoryFile::setFileInformation(const QJsonObject &info) {
     m_FileInformation = info;
 }

--- a/src/qarchiveextractor_p.cc
+++ b/src/qarchiveextractor_p.cc
@@ -32,7 +32,7 @@ using namespace QArchive;
 /// destructor.
 MutableMemoryFile::MutableMemoryFile() = default;
 MutableMemoryFile::~MutableMemoryFile() {
-    m_Buffer.clear();
+    m_Buffer = {};
 }
 
 void MutableMemoryFile::setFileInformation(const QJsonObject &info) {
@@ -47,7 +47,7 @@ QJsonObject MutableMemoryFile::getFileInformation() const {
     return m_FileInformation;
 }
 
-QSharedPointer<QBuffer> MutableMemoryFile::getBuffer() const {
+std::shared_ptr<QBuffer> MutableMemoryFile::getBuffer() const {
     return m_Buffer;
 }
 /// ---

--- a/src/qarchiveextractor_p.cc
+++ b/src/qarchiveextractor_p.cc
@@ -35,7 +35,7 @@ void MutableMemoryFile::setFileInformation(const QJsonObject &info) {
 }
 
 void MutableMemoryFile::setBuffer(QBuffer *buffer) {
-    m_Buffer.reset(buffer);
+    m_Buffer = std::make_shared<QBuffer>(buffer);
 }
 
 QJsonObject MutableMemoryFile::getFileInformation() const {

--- a/src/qarchivememoryfile.cc
+++ b/src/qarchivememoryfile.cc
@@ -7,9 +7,9 @@ MemoryFile::MemoryFile(QJsonObject info, std::shared_ptr<QBuffer> buffer)
       m_Buffer(std::move(buffer)) { }
 
 QJsonObject MemoryFile::fileInformation() const {
-    return {m_FileInformation};
+    return m_FileInformation;
 }
 
-QBuffer *MemoryFile::buffer() const {
-    return m_Buffer.get();
+std::shared_ptr<QBuffer> MemoryFile::buffer() const {
+    return m_Buffer;
 }

--- a/src/qarchivememoryfile.cc
+++ b/src/qarchivememoryfile.cc
@@ -5,12 +5,12 @@ using namespace QArchive;
 MemoryFile::MemoryFile()
     : m_Buffer(nullptr) { }
 
-MemoryFile::MemoryFile(QJsonObject info, const QSharedPointer<QBuffer> &buffer)
+MemoryFile::MemoryFile(QJsonObject info, std::shared_ptr<QBuffer> buffer)
     : m_FileInformation(std::move(info)),
-      m_Buffer(buffer) { }
+      m_Buffer(std::move(buffer)) { }
 
 MemoryFile::~MemoryFile() {
-    m_Buffer.clear();
+    m_Buffer = {};
 }
 
 QJsonObject MemoryFile::fileInformation() const {
@@ -18,5 +18,5 @@ QJsonObject MemoryFile::fileInformation() const {
 }
 
 QBuffer *MemoryFile::buffer() const {
-    return m_Buffer.data();
+    return m_Buffer.get();
 }

--- a/src/qarchivememoryfile.cc
+++ b/src/qarchivememoryfile.cc
@@ -2,16 +2,9 @@
 
 using namespace QArchive;
 
-MemoryFile::MemoryFile()
-    : m_Buffer(nullptr) { }
-
 MemoryFile::MemoryFile(QJsonObject info, std::shared_ptr<QBuffer> buffer)
     : m_FileInformation(std::move(info)),
       m_Buffer(std::move(buffer)) { }
-
-MemoryFile::~MemoryFile() {
-    m_Buffer = {};
-}
 
 QJsonObject MemoryFile::fileInformation() const {
     return {m_FileInformation};


### PR DESCRIPTION
This replaces QSharedPointer with std::shared_ptr.

Only real reason to do so is because various tools like clang-tidy understand it better. Plus it supports std::move. 

OTOH I don't know if this is a correct transformation as the original used clear(). Tests pass. Please review.

- [x] Refactor
