### PR TITLE
meson: add libarchive subproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ target_wrapper.*
 # QtCreator CMake
 CMakeLists.txt.user*
 
-# QtCreator 4.8< compilation database 
+# QtCreator 4.8< compilation database
 compile_commands.json
 
 # QtCreator local machine specific files for imported projects
@@ -54,3 +54,8 @@ examples/conan/build
 
 # build dir
 build
+
+#VSCode and CLion dirs
+.idea
+.vscode
+*~

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,2 @@
+/*/
+!packagefiles/

--- a/subprojects/libarchive.wrap
+++ b/subprojects/libarchive.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = libarchive-3.6.2
+source_url = https://github.com/libarchive/libarchive/releases/download/v3.6.2/libarchive-3.6.2.tar.xz
+source_filename = libarchive-3.6.2.tar.xz
+source_hash = 9e2c1b80d5fbe59b61308fdfab6c79b5021d7ff4ff2489fb12daf0a96a83551d
+patch_filename = libarchive_3.6.2-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libarchive_3.6.2-1/get_patch
+patch_hash = 155e46e26b027e43731dc79ed8c6968d6694accc07eef076a65285c1883b7c56
+wrapdb_version = 3.6.2-1
+
+[provide]
+libarchive = libarchive_dep


### PR DESCRIPTION
Allows to compile QArchive without host libarchive.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

- [x] Build-related changes

