### PR TITLE
Add raw format support

### DIFF
--- a/docs/QArchiveDiskExtractor.md
+++ b/docs/QArchiveDiskExtractor.md
@@ -50,6 +50,8 @@ The class belongs to the QArchive namespace , so make sure to include it.
 | **void**  | [addIncludePattern](#void-addincludepatternconst-qstringlist-patterns)(const QStringList&)     |
 | **void**  | [addExcludePattern](#void-addexcludepatternconst-qstring-pattern)(const QString&)              |
 | **void**  | [addExcludePattern](#void-addexcludepatternconst-qstringlist-patterns)(const QStringList&)     |
+| **void**  | [setRawMode](#void-setrawmode-bool-enabled)(bool)     |
+| **void**  | [setRawOutputFilename](#void-setrawoutputfilenameconst-qstring-name)(const QString&)     |
 | **void**  | [setPassword](#void-setpasswordconst-qstring-password)(const QString&)                         |
 | **void**  | [setBlocksize](#void-setblocksizeint-size)(int size)                                           |
 | **void**  | [getInfo](#void-getinfovoid)(void)                                                             |
@@ -297,6 +299,22 @@ considered.
 This is an overloaded function. Adds the given list of exclude pattern.
 
 > Note: Only available from QArchive v2.2.0
+
+---
+
+### void setRawMode(bool enabled)
+<p align="right"><code>[SLOT]</code></p>
+
+When enabled, the extraction is performed in 
+[raw mode](https://github.com/libarchive/libarchive/wiki/FormatRaw).
+
+---
+
+### void setRawOutputFilename(const QString &name)
+<p align="right"><code>[SLOT]</code></p>
+
+Sets raw mode to enabled. By default, the file extracted in raw mode is named `data`,
+as archive metadata is not available. This can be changed by providing the name here.
 
 ---
 

--- a/docs/QArchiveMemoryExtractor.md
+++ b/docs/QArchiveMemoryExtractor.md
@@ -48,6 +48,7 @@ The class belongs to the QArchive namespace, so make sure to include it.
 | **void**  | [addIncludePattern](#void-addincludepatternconst-qstringlist-patterns)(const QStringList&)     |
 | **void**  | [addExcludePattern](#void-addexcludepatternconst-qstring-pattern)(const QString&)              |
 | **void**  | [addExcludePattern](#void-addexcludepatternconst-qstringlist-patterns)(const QStringList&)     |
+| **void**  | [setRawMode](#void-setrawmode-bool-enabled)(bool)     |
 | **void**  | [setPassword](#void-setpasswordconst-qstring-password)(const QString&)                         |
 | **void**  | [setBlocksize](#void-setblocksizeint-size)(int size)                                           |
 | **void**  | [getInfo](#void-getinfovoid)(void)                                                             |
@@ -245,6 +246,14 @@ considered.
 This is an overloaded function. Adds the given list of exclude pattern.
 
 > Note: Only available from QArchive v2.2.0
+
+---
+
+### void setRawMode(bool enabled)
+<p align="right"><code>[SLOT]</code></p>
+
+When set to `true`, the extraction is performed in 
+[raw mode](https://github.com/libarchive/libarchive/wiki/FormatRaw).
 
 ---
 

--- a/include/qarchiveextractor.hpp
+++ b/include/qarchiveextractor.hpp
@@ -36,6 +36,8 @@ class QARCHIVE_EXPORT Extractor : public QObject {
     void addExcludePattern(const QString&);
     void addExcludePattern(const QStringList&);
     void setBasePath(const QString&);
+    void setRawMode(bool);
+    void setRawOutputFilename(const QString&);
     void clear();
 
     void getInfo();

--- a/include/qarchiveextractor_p.hpp
+++ b/include/qarchiveextractor_p.hpp
@@ -53,6 +53,8 @@ class ExtractorPrivate : public QObject {
     void addExcludePattern(const QString&);
     void addExcludePattern(const QStringList&);
     void setBasePath(const QString&);
+    void setRawMode(bool);
+    void setRawOutputFilename(const QString&);
     void clear();
 
     void getInfo();
@@ -69,6 +71,7 @@ class ExtractorPrivate : public QObject {
     short processArchiveInformation();
     short writeData(struct archive_entry*);
     short extract();
+    void toggleArchiveFormat(struct archive*);
   Q_SIGNALS:
     void started();
     void canceled();
@@ -83,6 +86,7 @@ class ExtractorPrivate : public QObject {
     void extractionRequirePassword(int);
   private:
     bool b_MemoryMode = false,
+         b_RawMode = false,
          b_ProcessingArchive = false,
          b_StartRequested = false;
 
@@ -105,7 +109,8 @@ class ExtractorPrivate : public QObject {
 
     QString m_OutputDirectory,
             m_Password,
-            m_ArchivePath;
+            m_ArchivePath,
+            m_RawOutputFilename;
     QIODevice *m_Archive = nullptr;
     archive_entry *m_CurrentArchiveEntry = nullptr;
     MutableMemoryFile m_CurrentMemoryFile;

--- a/src/qarchiveextractor.cc
+++ b/src/qarchiveextractor.cc
@@ -156,6 +156,20 @@ void Extractor::setBasePath(const QString &path) {
                       Q_ARG(QString, path));
 }
 
+void Extractor::setRawMode(bool enabled) {
+    getMethod(*m_Extractor,
+        "setRawMode(bool)").invoke(m_Extractor.get(),
+            Qt::QueuedConnection,
+            Q_ARG(bool, enabled));
+}
+
+void Extractor::setRawOutputFilename(const QString& path) {
+    getMethod(*m_Extractor,
+        "setRawOutputFilename(const QString&)").invoke(m_Extractor.get(),
+            Qt::QueuedConnection,
+            Q_ARG(QString, path));
+}
+
 void Extractor::clear() {
     getMethod(*m_Extractor, "clear()").invoke(m_Extractor.get(), Qt::QueuedConnection);
 }


### PR DESCRIPTION
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this pull request introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Describe your Pull Request:**
Add an option to extract using libarchive's [raw format](https://github.com/libarchive/libarchive/wiki/FormatRaw). It is not included when using `archive_read_support_format_all`, so one needs to enable it specifically. The format is useful for some unconvetionally compressed files, see [this libarchive issue](https://github.com/libarchive/libarchive/issues/1460) as an example.